### PR TITLE
Correcting fillRectangle semantics

### DIFF
--- a/SSD1331_t3.h
+++ b/SSD1331_t3.h
@@ -166,7 +166,7 @@ class SSD1331_t3 : public virtual SGL {
   int16_t drawRectangle_nodelay(uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint16_t color);
   int16_t drawFrame_nodelay(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint16_t outColor, uint16_t fillColor);
   int16_t fillRectangle_nodelay(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t color) __attribute__((always_inline)) {
-    return drawFrame_nodelay(x, y, x + w, y + h, color, color);
+    return drawFrame_nodelay(x, y, x + w - 1, y + h - 1, color, color);
   }
 
   /* Custom SSD1331 extensions */


### PR DESCRIPTION
Width/Height parameters weren't adjusted properly when translated to absolute-coordinate versions, causing "one too large" issues which had follow-on affects to things such as drawChar and the like from the underlying SGL libraries/code.
